### PR TITLE
Changed projects page response to scaling and card image size.

### DIFF
--- a/src/pages/Projects/projects.css
+++ b/src/pages/Projects/projects.css
@@ -7,8 +7,7 @@
 }
 
 .project-image{
-  max-width: 21rem;
-  max-height: 15rem;
+  width: 21rem;
   padding-bottom: 0rem;
 }
 
@@ -50,7 +49,7 @@
   padding-bottom: 0.6em;
 }
 
-@media screen and (max-width: 1260px){
+@media screen and (max-width: 1325px){
   .projects ul{
     grid-template-columns: 1fr 1fr;
   }
@@ -70,8 +69,7 @@
 
 @media screen and (max-width: 520px) {
   .project-image{
-    max-width:18rem;
-    max-height:15rem;
+    width:18rem;
   }
 
   .link-list-links{
@@ -85,22 +83,19 @@
   .projects li{
     height: 29rem;
   }
-}
 
-@media screen and (max-width: 465px){
-  .project-image{
-    max-width:15rem;
-    max-height:12rem;
+  .desc{
+    margin: 0 0rem 0 0rem;
   }
 }
 
 @media screen and (max-width: 432px){
   .project-image{
-    display:none;
+    width:15rem;
   }
 
   .projects li{
-    height: 17rem;
+    height: 25rem;
   }
 }
 


### PR DESCRIPTION
# Changes
## Projects page
- Made project images on cards a fixed width for a given viewport size.
- Changed max-width for two grid columns from ``1260px`` to ``1325px`` to fix issue where grid of cards was too wide for it's allocated space.
- Removed indent (``2rem`` margin on either side of ``desc`` divs) for Projects page when below or equal to ``520px``.
- Removed response to <= ``465px`` as it was no longer necessary given the above changes.
- Pictures no longer are set ``display: none`` when viewport is thinner than or equal to ``432px``. This has increased the height of the thinnest cards from ``17rem`` to ``25rem``.