### PR TITLE
Moved indent response to App.css

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -90,4 +90,8 @@ h3 {
     display:block;
     padding: 0.001rem;
   }
+
+  .desc{
+    margin: 0 0rem 0 0rem;
+  }
 }

--- a/src/pages/Projects/projects.css
+++ b/src/pages/Projects/projects.css
@@ -83,10 +83,6 @@
   .projects li{
     height: 29rem;
   }
-
-  .desc{
-    margin: 0 0rem 0 0rem;
-  }
 }
 
 @media screen and (max-width: 432px){


### PR DESCRIPTION
# Changes
## Whole app
- Unknowingly, I had made a change to the whole app by changing ``projects.css``, so I have moved the css change to global ``App.css`` in the interest of better organisation.\
This css causes the main page content indent to dissapear when the page width is <= ``520px``.